### PR TITLE
refactor: Remove db.json from .gitignore

### DIFF
--- a/familytree/.gitignore
+++ b/familytree/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+db.json


### PR DESCRIPTION
The `db.json` file was added to the `.gitignore` file to prevent it from being tracked by Git. This commit removes the entry for `db.json` from the `.gitignore` file.